### PR TITLE
Add cleaned_years.csv to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 
 # Cleaned years csv for compliance to github file size restrictions
 /data/combined_years.csv
-/data/dirty_sample.csv
+/data/clean_years.csv
+/data/clean_sample.csv
+
 
 *.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 # Created by https://www.gitignore.io/api/r
 
 # Cleaned years csv for compliance to github file size restrictions
-/data/cleaned_years.csv
+/data/combined_years.csv
+/data/dirty_sample.csv
 
 *.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 
 # Created by https://www.gitignore.io/api/r
 
+# Cleaned years csv for compliance to github file size restrictions
+/data/cleaned_years.csv
+
 *.zip
 
 ### R ###


### PR DESCRIPTION
For compliance with github file size restrictions, the 600mb+ file is ignored, but can still be stored locally in the /data folder to avoid merging the datasets again.
